### PR TITLE
Joining time

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -223,6 +223,7 @@ if not _G.VHUDPlus then
 				},
 				USE_REAL_AMMO 						= true,
 				ENABLE_IFBG							= true,
+				ENABLE_TIME_LEFT                    = true,
 			},
 			HUDChat = {
 				ENABLED									= true,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -889,6 +889,13 @@ if VHUDPlus then
 						value = {"CustomHUD", "ENABLE_IFBG"},
 					},
 					{
+						type = "toggle",
+						name_id = "wolfhud_enable_time_left_title",
+						desc_id = "wolfhud_enable_time_left_desc",
+						visible_reqs = {}, enabled_reqs = {},
+						value = {"CustomHUD", "ENABLE_TIME_LEFT"},
+					},
+					{
 						type = "divider",
 						size = 16,
 					},

--- a/lua/MenuTweaks.lua
+++ b/lua/MenuTweaks.lua
@@ -816,7 +816,7 @@ elseif string.lower(RequiredScript) == "lib/managers/menumanagerdialogs" then
 			local result = update_person_joining_original(self, id, progress_percentage, ...)
 			local time_left = (t / progress_percentage) * (100 - progress_percentage)
 			local dialog = managers.system_menu:get_dialog("user_dropin" .. id)
-			if dialog and time_left then
+			if dialog and time_left and VHUDPlus:getSetting({"CustomHUD", "ENABLE_TIME_LEFT"}, true) then
 				dialog:set_text(managers.localization:text("dialog_wait") .. string.format(" %d%% (%0.2fs)", progress_percentage, time_left))
 			end
 		end


### PR DESCRIPTION
An option to hide the timer

I wasnt sure where in the options menu still would fit so i stuck it right next to the flashbang option

this have no localization yet but I think something like this might do:

"wolfhud_enable_time_left_title" : "Ingame join remaining",
"wolfhud_enable_time_left_desc" : "In-game joining dialog will show you how many seconds left"