### PR TITLE
Add an option to hide the ping text

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -313,6 +313,7 @@ if not _G.VHUDPlus then
 				SHOW_IN_CS_LOBBY 						= true,
 				SHOW_ON_STATS_PANEL						= true,
                 REPLACE_PROFILE_MENU                    = true,
+				ENABLE_PEER_PING                        = true,
 			},
 			HUDList = {
 				ENABLED	 								= true,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -3733,6 +3733,17 @@ if VHUDPlus then
 						value = {"CrewLoadout", "REPLACE_PROFILE_MENU"},
 						visible_reqs = {}, enabled_reqs = {},
 					},
+					{
+						type = "divider",
+						size = 16,
+					},
+					{
+						type = "toggle",
+						name_id = "wolfhud_enable_peer_ping_title",
+						desc_id = "wolfhud_enable_peer_ping_desc",
+						value = {"CrewLoadout", "ENABLE_PEER_PING"},
+						visible_reqs = {}, enabled_reqs = {},
+					},
 				},
 			},
 			{

--- a/lua/MenuTweaks.lua
+++ b/lua/MenuTweaks.lua
@@ -681,7 +681,7 @@ elseif string.lower(RequiredScript) == "lib/managers/menu/contractboxgui" then
 	function ContractBoxGui:create_character_text(peer_id, ...)
 		create_character_text_original(self, peer_id, ...)
 
-		if managers.network:session() then
+		if managers.network:session() and VHUDPlus:getSetting({"CrewLoadout", "ENABLE_PEER_PING"}, true) then
 			if managers.network:session():local_peer():id() ~= peer_id then
 				local peer_label = self._peers[peer_id]
 				if alive(peer_label) then
@@ -703,7 +703,7 @@ elseif string.lower(RequiredScript) == "lib/managers/menu/contractboxgui" then
 						alpha = 0.8,
 						blend_mode = "add"
 					})
-					self._peer_latency[peer_id]:set_text( latency > 0 and string.format("%.0fms", latency) or "---ms" )
+					self._peer_latency[peer_id]:set_text( latency > 0 and string.format("%.0fms", latency) or "" )
 					self._peer_latency[peer_id]:set_visible(self._enabled)
 					local _, _, w, h = self._peer_latency[peer_id]:text_rect()
 					self._peer_latency[peer_id]:set_size(w, h)


### PR DESCRIPTION
simple lets you hide the ping text in the lobby  
localization would be something like:

"wolfhud_enable_peer_ping_title" : "Display ping in lobby",
"wolfhud_enable_peer_ping_desc" : "Display how much ping each player in the lobby have."

