### PR TITLE
Drivinghud tempfix

### DIFF
--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1532,6 +1532,7 @@ if VHUDPlus then
 								value = {"DrivingHUD", "ENABLED"},
 							},
 							{
+								--[[
 								type = "slider",
 								name_id = "wolfhud_drivinghud_scale_title",
 								desc_id = "wolfhud_drivinghud_scale_desc",
@@ -1545,6 +1546,7 @@ if VHUDPlus then
 								step_size = 0.01,
 							},
 							{
+								]]
 								type = "divider",
 								size = 16,
 							},

--- a/lua/DrivingHUD.lua
+++ b/lua/DrivingHUD.lua
@@ -105,6 +105,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			valign = "bottom",
 			layer = 1,
 			wrap = false,
+		        visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_SPEED"}, true),
 			word_wrap = false
 		})
 		
@@ -122,6 +123,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			valign = "bottom",
 			layer = 1,
 			wrap = false,
+		        visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_RPM"}, true),
 			word_wrap = false
 		})
 		
@@ -139,6 +141,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			valign = "bottom",
 			layer = 1,
 			wrap = false,
+			visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_GEAR"}, true),
 			word_wrap = false
 		})
 		
@@ -156,6 +159,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			valign = "bottom",
 			layer = 1,
 			wrap = false,
+			visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_PASSENGERS"}, true),
 			word_wrap = false
 		})
 		
@@ -165,10 +169,10 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			vertical = "bottom",
 			valign = "bottom",
 			name = "seats_bitmap",
-			visible = true,
 			layer = 1,
 			texture = "assets/guis/textures/contact_vlad",
 			texture_rect = seats_texture_rect,
+			visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_PASSENGERS"}, true),
 			x = self.drivingpanel:w() - (x_pos),
 			y = self.drivingpanel:h() + (y_pos + -110),
 			w = seats_texture_rect[3] / 4,
@@ -191,6 +195,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			valign = "bottom",
 			layer = 1,
 			wrap = false,
+			visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_LOOT"}, true),
 			word_wrap = false
 		})
 		local loot_texture_rect = {1840, 63, 160, 137}
@@ -199,10 +204,10 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			vertical = "bottom",
 			valign = "bottom",
 			name = "loot_bitmap",
-			visible = true,
 			layer = 1,
 			texture = "assets/guis/textures/contact_vlad",
 			texture_rect = loot_texture_rect,
+			visible = VHUDPlus:getSetting({"DrivingHUD", "SHOW_LOOT"}, true),
 			x = self.drivingpanel:w() - (x_pos),
 			y = self.drivingpanel:h() + (y_pos + -120),
 			w = loot_texture_rect[3] / 8,


### PR DESCRIPTION
This just adds the ability to at least disable some of the info in drivinghud. This is not really an ideal fix as it just hides the parts you dont want to see leaving gaps between some meters.

But the loot info and passanger info looks good side by side and thats really all the information thats useful anyway,

Also commented out the sacle option in the optionsmenu as it does nothing right now and might be confusing.