### PR TITLE
Flashbang glare

### DIFF
--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -882,6 +882,7 @@ if VHUDPlus then
 						value = {"CustomHUD", "USE_REAL_AMMO"},
 					},
 					{
+					--[[	
 						type = "toggle",
 						name_id = "wolfhud_invertedfbg_title",
 						desc_id = "wolfhud_invertedfbg_desc",
@@ -889,6 +890,7 @@ if VHUDPlus then
 						value = {"CustomHUD", "ENABLE_IFBG"},
 					},
 					{
+					]]	
 						type = "toggle",
 						name_id = "wolfhud_enable_time_left_title",
 						desc_id = "wolfhud_enable_time_left_desc",

--- a/lua/Scripts.lua
+++ b/lua/Scripts.lua
@@ -73,6 +73,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		end
 	end
 
+--[[
 	local previous_value = 0
 
 	-- local update_actual = HUDManager.update
@@ -434,6 +435,7 @@ elseif string.lower(RequiredScript) == "core/lib/managers/coreenvironmentcontrol
 			self._lut_modifier_material:set_variable(ids_LUT_contrast, flashbang * 0.5)
 		end
 	end
+]]	
 elseif string.lower(RequiredScript) == "lib/tweak_data/timespeedeffecttweakdata" then
 	local init_original = TimeSpeedEffectTweakData.init
 	local FORCE_ENABLE = {


### PR DESCRIPTION
In this current build  the flashbang glare completely removes the hud each time you are hit by one.
I have to go into the video setting every time to enable the hud again.
I don't use this option because I prefer the white over the black glare.
The reason I think this should be taken out is that I don't like when options I don't want to use still affects me and even more so in this case.

So please consider taking it out, its a good idea to have it as an option but it causes more harm than it helps.