### PR TITLE
New optional setting for an alt icon for pacified civillians

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -286,6 +286,7 @@ if not _G.VHUDPlus then
 				SHOW_PERCENTAGE_OUTLINE					= true,
 				SHOW_BARS								= true,
 				SHOW_PACIFIED_CIVILIANS					= true,
+				SHOW_PACIFIED_CIVILIANS_ALT_ICON        = true,
 				REMOVE_ANSWERED_PAGER_CONTOUR 			= true,
 			},
 			DrivingHUD = {

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1091,6 +1091,20 @@ if VHUDPlus then
 							},
 							{
 								type = "toggle",
+								name_id = "wolfhud_pacified_civs_alt_icon_title",
+								desc_id = "wolfhud_pacified_civs_alt_icon_desc",
+								visible_reqs = {},
+								enabled_reqs = {
+									{ setting = { "HUDSuspicion", "SHOW_PACIFIED_CIVILIANS" }, invert = false },
+								},
+								value = {"HUDSuspicion", "SHOW_PACIFIED_CIVILIANS_ALT_ICON"},
+							},
+							{
+								type = "divider",
+								size = 24,
+							},
+							{
+								type = "toggle",
 								name_id = "wolfhud_hudlist_remove_answered_pagers_title",
 								desc_id = "wolfhud_hudlist_remove_answered_pagers_desc",
 								visible_reqs = {}, enabled_reqs = {},

--- a/lua/PacifiedCivs.lua
+++ b/lua/PacifiedCivs.lua
@@ -13,9 +13,14 @@ function GroupAIStateBase:_upd_criminal_suspicion_progress(...)
 						if not obs_susp_data._subdued_civ then
 							obs_susp_data._alerted_civ = nil
 							obs_susp_data._subdued_civ = true
+						if VHUDPlus:getSetting({"HUDSuspicion", "SHOW_PACIFIED_CIVILIANS_ALT_ICON"}, true) then	
+							waypoint.bitmap:set_color(Color(0.0, 1.0, 0.0))
+							waypoint.arrow:set_color(Color(0.75, 0, 0.3, 0))
+						else
 							color = Color(0, 0.71, 1)
 							arrow_color = Color(0, 0.35, 0.5)
 							waypoint.bitmap:set_image("guis/textures/menu_singletick")
+					        end
 						end
 					elseif obs_susp_data.alerted then
 						if not obs_susp_data._alerted_civ then


### PR DESCRIPTION
Instead of replacing the icon with a green one this option lets you pick an optional texture for the icon in the options

No localization included in the merge

	"wolfhud_pacified_civs_alt_icon_title" : "Alternative icon",
	"wolfhud_pacified_civs_alt_icon_desc" : "An optional green icon for pacified civilians",