### PR TITLE
inspire timer fix

### DIFF
--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -355,7 +355,7 @@ elseif RequiredScript == "lib/managers/hud/hudteammate" then
 		local visible = icon_data ~= "mugshot_normal"
 		self:set_stamina_meter_visibility(not visible and VHUDPlus:getSetting({"CustomHUD", "PLAYER", "STAMINA"}, true))
 		self:set_armor_timer_visibility(not visible)
-		self:set_inspire_timer_visibility(not visible)
+		self:set_inspire_timer_visibility(not visible and VHUDPlus:getSetting({"CustomHUD", "PLAYER", "INSPIRE"}, true))
 		-- self:set_inf_ammo_visibility(not visible and )
 		--[[
 		local teammate_panel = self._panel:child( "player" )


### PR DESCRIPTION
This should finally fix the problem where the timer is visible in vehicles!

Now just to figure out why it has no black outline like the armor timer and why its underneath the health bar..