### PR TITLE
inspire timer outline fix

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -728,6 +728,26 @@ if not _G.VHUDPlus then
 		end
 	end
 
+	function VHUDPlus:MakeOutlineText(panel, bg, txt)
+                bg.name = nil
+                local bgs = {}
+              
+		for i = 1, 4 do
+                table.insert(bgs, panel:text(bg))
+                end
+                
+		bgs[1]:set_x(txt:x() - 1)
+                bgs[1]:set_y(txt:y() - 1)
+                bgs[2]:set_x(txt:x() + 1)
+                bgs[2]:set_y(txt:y() - 1)
+                bgs[3]:set_x(txt:x() - 1)
+                bgs[3]:set_y(txt:y() + 1)
+                bgs[4]:set_x(txt:x() + 1)
+                bgs[4]:set_y(txt:y() + 1)
+                
+		return bgs
+        end
+	
 	function VHUDPlus:createDirectory(path)
 		local current = ""
 		path = Application:nice_path(path, true):gsub("\\", "/")

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -435,7 +435,7 @@ elseif RequiredScript == "lib/managers/hud/hudteammate" then
 			layer = 4
 		})
 		self._inspire_timer:set_right(self._player_panel:child("radial_health_panel"):right())
-		self._inspire_timer_bg = OutlinedText:new(self._player_panel, {
+		self._inspire_timer_bg = VHUDPlus:MakeOutlineText(self._player_panel, {
 			text = "",
 			color = Color.black:with_alpha(0.5),
 			visible = false,


### PR DESCRIPTION
Fixes the problem with the inspire timer, the outline code is taken from sydneyhud.
I have no idea myself why the outline wont work the same for the inspire timer as it does for the armor timer but either way, its now fixed if you choose to add this in.