### PR TITLE
Headshot circle marker

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -23,7 +23,7 @@ if not _G.VHUDPlus then
 		["lib/managers/hudmanager"] 								= { "EnemyHealthbar.lua", "CustomWaypoints.lua", "EnemyHealthbarAlt.lua" },
 		["lib/managers/hudmanagerpd2"] 								= {  "VanillaHUD.lua", "HUDChat.lua", "HUDList.lua", "KillCounter.lua", "DownCounter.lua", "DrivingHUD.lua", "DamageIndicator.lua", "WaypointsManager.lua", "Interaction.lua", "Scripts.lua", "BurstFire.lua", "AdvAssault.lua", "TabStats.lua" },
 		["lib/managers/statisticsmanager"] 							= { "KillCounter.lua", "TabStats.lua" },
-		["lib/managers/playermanager"] 								= { "GameInfoManager.lua", "BurstFire.lua", "VanillaHUD.lua" },
+		["lib/managers/playermanager"] 								= { "GameInfoManager.lua", "BurstFire.lua", "VanillaHUD.lua", "Scripts.lua" },
 		["lib/managers/preplanningmanager"] 						= { "PrePlanManager.lua" },
 		["lib/managers/hud/huddriving"] 							= { "DrivingHUD.lua" },
 		["lib/managers/hud/hudteammate"] 							= { "VanillaHUD.lua", "KillCounter.lua", "DownCounter.lua", "BurstFire.lua" },
@@ -114,6 +114,7 @@ if not _G.VHUDPlus then
 		["lib/managers/skirmishmanager"] 							= { "RichPresence.lua" },
 		["core/lib/managers/coreenvironmentcontrollermanager"] 		= { "Scripts.lua" },
 		["lib/managers/menu/preplanningmapgui"]						= { "PrePlanManager.lua" },
+		["lib/managers/hud/hudhitconfirm"] 							= { "Scripts.lua" },
 
 		--Utils and custom classes...
 		["lib/entry"]												= { "Utils/QuickInputMenu.lua", "Utils/LoadoutPanel.lua", "Utils/OutlinedText.lua" },
@@ -224,6 +225,7 @@ if not _G.VHUDPlus then
 				USE_REAL_AMMO 						= true,
 				ENABLE_IFBG							= true,
 				ENABLE_TIME_LEFT                    = true,
+				HEADSHOT                            = true,
 			},
 			HUDChat = {
 				ENABLED									= true,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -896,6 +896,13 @@ if VHUDPlus then
 						value = {"CustomHUD", "ENABLE_TIME_LEFT"},
 					},
 					{
+						type = "toggle",
+						name_id = "wolfhud_enable_headshot_title",
+						desc_id = "wolfhud_enable_headshot_desc",
+						visible_reqs = {}, enabled_reqs = {},
+						value = {"CustomHUD", "HEADSHOT"},	
+					},
+					{
 						type = "divider",
 						size = 16,
 					},

--- a/lua/Scripts.lua
+++ b/lua/Scripts.lua
@@ -274,6 +274,45 @@ elseif string.lower(RequiredScript) == "core/lib/managers/coreenvironmentcontrol
 			return set_post_composite_actual(self, t, dt)
 		end
 	end
+elseif string.lower(RequiredScript) == "lib/managers/hud/hudhitconfirm" then
+	local old_init = HUDHitConfirm.init
+	function HUDHitConfirm:init(...)
+		old_init(self, ...)
+		local size = 24
+		local red = (80)/100
+		local green = (20)/100
+		local blue = (20)/100
+		local new_color = Color(red, green, blue)
+		if self._hud_panel:child("headshot_confirm") then
+			self._hud_panel:remove(self._hud_panel:child("headshot_confirm"))
+		end
+		self._headshot_confirm = self._hud_panel:bitmap({
+			valign = "center",
+			halign = "center",
+			visible = false,
+			name = "headshot_confirm",
+			texture = "guis/textures/pd2/hud_progress_active",
+			color = new_color,
+			layer = 1,
+			h = size,
+			w = size,
+			blend_mode = "normal"
+		})
+		self._headshot_confirm:set_center(self._hud_panel:w() / 2, self._hud_panel:h() / 2)
+	end
+	function HUDHitConfirm:on_headshot_confirmed()
+	if VHUDPlus:getSetting({"CustomHUD", "HEADSHOT"}, true) then
+		self._headshot_confirm:stop()
+		self._headshot_confirm:animate(callback(self, self, "_animate_show"), callback(self, self, "show_done"), 0.25)
+	end
+	end
+	
+elseif string.lower(RequiredScript) == "lib/managers/playermanager" then
+	local old_ohd = PlayerManager.on_headshot_dealt
+	function PlayerManager:on_headshot_dealt(...)
+		managers.hud:on_headshot_confirmed()
+		return old_ohd(self, ...)
+	end
 elseif string.lower(RequiredScript) == "lib/tweak_data/timespeedeffecttweakdata" then
 	local init_original = TimeSpeedEffectTweakData.init
 	local FORCE_ENABLE = {

--- a/mod.txt
+++ b/mod.txt
@@ -110,6 +110,7 @@
 		{ "hook_id" : "lib/managers/skirmishmanager", 							"script_path" : "Core.lua" },
 		{ "hook_id" : "core/lib/managers/coreenvironmentcontrollermanager", 	"script_path" : "Core.lua" },
 		{ "hook_id" : "lib/managers/menu/preplanningmapgui", 					"script_path" : "Core.lua" },
+		{ "hook_id" : "lib/managers/hud/hudhitconfirm", 					    "script_path" : "Core.lua" },
 
 		{ "hook_id" : "lib/entry", 												"script_path" : "Core.lua" },
 		{ "hook_id" : "lib/managers/systemmenumanager", 						"script_path" : "Core.lua" },


### PR DESCRIPTION
This adds an option for a headshot confirm circle.
Its made by Schmuddel

Not localized yet but it could be something like this if you choose to add it in:

"wolfhud_enable_headshot_title" : "Head shot confirm circle",
"wolfhud_enable_headshot_desc" : "Adds a circle around hit marks when you perform a head shot",