### PR TITLE
Enemy health bar fix

### DIFF
--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1278,7 +1278,9 @@ if VHUDPlus then
 								type = "toggle",
 								name_id = "wolfhud_enemyhealthbar_enable_enemy_health_circle",
 								desc_id = "wolfhud_enemyhealthbar_enable_enemy_health_circle_desc",
-								visible_reqs = {}, enabled_reqs = {},
+								visible_reqs = {}, enabled_reqs = {
+								    { setting = { "EnemyHealthbar", "ENABLED_ALT" }, invert = true },
+								},
 								value = {"EnemyHealthbar", "ENABLED"},
 							},
 							{

--- a/lua/EnemyHealthbar.lua
+++ b/lua/EnemyHealthbar.lua
@@ -1,3 +1,5 @@
+if not (VHUDPlus and VHUDPlus:getSetting({"EnemyHealthbar", "ENABLED"}, true)) then return end
+
 if string.lower(RequiredScript) == "lib/managers/hudmanager" then
 
 local _setup_player_info_hud_pd2_original = HUDManager._setup_player_info_hud_pd2


### PR DESCRIPTION
Disables the whole circle health code when not being used.
Adds a check in the options so you can't have both active at the same time because why would you.