### PR TITLE
Enemy health bar fix

### DIFF
--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1278,7 +1278,9 @@ if VHUDPlus then
 								type = "toggle",
 								name_id = "wolfhud_enemyhealthbar_enable_enemy_health_circle",
 								desc_id = "wolfhud_enemyhealthbar_enable_enemy_health_circle_desc",
-								visible_reqs = {}, enabled_reqs = {},
+								visible_reqs = {}, enabled_reqs = {
+								    { setting = { "EnemyHealthbar", "ENABLED_ALT" }, invert = true },
+								},
 								value = {"EnemyHealthbar", "ENABLED"},
 							},
 							{

--- a/lua/EnemyHealthbar.lua
+++ b/lua/EnemyHealthbar.lua
@@ -1,3 +1,5 @@
+if not (VHUDPlus and VHUDPlus:getSetting({"EnemyHealthbar", "ENABLED"}, true)) then return end
+
 if string.lower(RequiredScript) == "lib/managers/hudmanager" then
 
 local _setup_player_info_hud_pd2_original = HUDManager._setup_player_info_hud_pd2

--- a/lua/EnemyHealthbar.lua
+++ b/lua/EnemyHealthbar.lua
@@ -1,4 +1,4 @@
-if not (VHUDPlus and VHUDPlus:getSetting({"EnemyHealthbar", "ENABLED"}, true)) then return end
+if VHUDPlus:getSetting({"EnemyHealthbar", "ENABLED_ALT"}, true) then return end
 
 if string.lower(RequiredScript) == "lib/managers/hudmanager" then
 


### PR DESCRIPTION
Fixes the problems with the enemy health
adds a check in the options so both the bar and circle can be active at the same time

fixed it so if the bar is enabled the circle health wont be active