### PR TITLE
smaller underdog glow

### DIFF
--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -471,8 +471,8 @@ elseif RequiredScript == "lib/managers/hud/hudteammate" then
 		local underdog_glow = radial_health_panel:bitmap({
 			valign 			= "center",
 			halign 			= "center",
-			w 				= 64,
-			h 				= 64,
+			w 				= 50,
+			h 				= 50,
 			name 			= "underdog_glow",
 			visible 		= false,
 			texture 		= "guis/textures/pd2/crimenet_marker_glow",


### PR DESCRIPTION
Making a second attempt with this but with some additional info.

Right now when underdog aced is active a obvious square is showing up around the health circle.
Here is a picture of how it looks at the size of 64:
![64](https://user-images.githubusercontent.com/30779314/73120016-7d07ca80-3f69-11ea-97be-64dfd3968cab.png)

It's much easier to see in game but its still visible in the corners here.

But changing the size from 64 down to 50 making it slightly smaller will put the square inside the health circle making it much less obvious:

![50 1](https://user-images.githubusercontent.com/30779314/73120044-d1ab4580-3f69-11ea-98db-01e7c1f0a559.png)



