### PR TITLE
own joker crash fix

### DIFF
--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -1297,7 +1297,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		local minion_list = self:list("left_side_list"):item("minions")
 
 		for name, item in pairs(minion_list:items()) do
-			item:set_active(not HUDListManager.ListOptions.show_own_minions_only or data.owner == managers.network:session():local_peer():id())
+			item:set_active(not HUDListManager.ListOptions.show_own_minions_only)
 		end
 	end
 


### PR DESCRIPTION
changing the options to show own jokers only while already having active jokers alive will cause a crash.

With this edit the already existing jokers won't show on the hud when changing the option mid game. 
Any new jokers taken will show on the hud like normal.