### PR TITLE
enemy health fix

### DIFF
--- a/lua/EnemyHealthbar.lua
+++ b/lua/EnemyHealthbar.lua
@@ -1,3 +1,5 @@
+if VHUDPlus:getSetting({"EnemyHealthbar", "ENABLED_ALT"}, true) then return end
+
 if string.lower(RequiredScript) == "lib/managers/hudmanager" then
 
 local _setup_player_info_hud_pd2_original = HUDManager._setup_player_info_hud_pd2


### PR DESCRIPTION
My reason for putting that check there was not to prevent both health bars being visible at the same time. It was to prevent the enemy health bar from not updating properly when killing an enemy.

Without that or something that  gives the same result the enemy health bar will show full health when a target is dead which does not look good at all. Providing that you one shot them, however the health will remain whatever value it was before the killing shot.