### PR TITLE
Tab stats fix

### DIFF
--- a/WolfHUDTweakData.lua
+++ b/WolfHUDTweakData.lua
@@ -91,8 +91,8 @@ function WolfHUDTweakData:init()
 										{ "deployable", "secondary_deployable" }
 									}
 	self.TAB_LOADOUT_LAYOUT = 		{
-										{ "name", "ping" },
-										{ "skills", "perk", "playtime" },
+										{ "name", "ping", "playtime" },
+										{ "skills", "perk" },
 									}
 
 	-- Color table

--- a/lua/EnhancedCrewLoadout.lua
+++ b/lua/EnhancedCrewLoadout.lua
@@ -767,8 +767,8 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/newhudstatsscreen" then
 						level = 	{ font_size = tweak_data.menu.pd2_medium_font_size * 0.90, height = tweak_data.menu.pd2_medium_font_size * 0.95, align = "left",  margin = 0, use_peer_color = true },
 						skills = 	{ font_size = tweak_data.menu.pd2_small_font_size  * 1.10, height = tweak_data.menu.pd2_small_font_size  * 1.15, align = "left",  margin = 3 },
 						perk = 		{ font_size = tweak_data.menu.pd2_medium_font_size * 0.95, height = tweak_data.menu.pd2_medium_font_size * 1.00, align = "left",  margin = 3 },
-						ping = 		{ font_size = tweak_data.menu.pd2_small_font_size  * 0.75, height = tweak_data.menu.pd2_small_font_size  * 0.80, align = "right" 			 },
-						playtime = 	{ font_size = tweak_data.menu.pd2_small_font_size  * 0.75, height = tweak_data.menu.pd2_small_font_size  * 0.80, align = "left" 			 },
+						ping = 		{ font_size = tweak_data.menu.pd2_small_font_size  * 0.75, height = tweak_data.menu.pd2_small_font_size  * 0.80, align = "left" 			 },
+						playtime = 	{ font_size = tweak_data.menu.pd2_small_font_size  * 0.75, height = tweak_data.menu.pd2_small_font_size  * 0.80, align = "right"             },
 						default = 	{ hide_name = true },
 						margin = 5,
 						borders = { 0, 0, 0, 2 }


### PR DESCRIPTION
Apparently all the player info wont fit when having the hour info/ping info next to the skills/perk info.

I tweaked it around and this is the best looking result that will let you see all the info with no cutting off.

The ping will be right next to the name and the hour display will be where ping was before. 