### PR TITLE
Drill icons

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -530,6 +530,7 @@ if not _G.VHUDPlus then
 				SUPRESS_NADES_STEALTH					= true,
 				HOLD2PICK								= true,
 				CUSTOM_HUDS_SUPPORT						= false,
+				DRILL_ICONS                             = false,				
 			},
 			GADGETS = {
 				LASER_AUTO_ON 							= true,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -3673,6 +3673,20 @@ if VHUDPlus then
 					},
 					{
 						type = "toggle",
+						name_id = "wolfhud_drill_icons_title",
+						desc_id = "wolfhud_drill_icons_desc",
+						value = {"INTERACTION", "DRILL_ICONS"},
+						visible_reqs = {
+						    { setting = { "INTERACTION", "CUSTOM_HUDS_SUPPORT" }, invert = true }
+						},
+						enabled_reqs = {},
+					},
+					{
+						type = "divider",
+						size = 8,
+					},
+					{						
+						type = "toggle",
 						name_id = "wolfhud_press2hold_show_timer_title",
 						desc_id = "wolfhud_press2hold_show_timer_desc",
 						value = {"INTERACTION", "SHOW_TIME_REMAINING"},

--- a/lua/Interaction.lua
+++ b/lua/Interaction.lua
@@ -322,12 +322,17 @@ local custom_huds_support = VHUDPlus:getSetting({"INTERACTION", "CUSTOM_HUDS_SUP
 		self._interact_visible = nil
 		return remove_interact_original(self)
 	end
+	
+	function HUDManager:show_drill_interact(...)
+	    self._hud_interaction:show_drill_interact(...)
+    end
 
 elseif string.lower(RequiredScript) == "lib/managers/hud/hudinteraction" then
 	local init_original 				= HUDInteraction.init
 	local show_interaction_bar_original = HUDInteraction.show_interaction_bar
 	local hide_interaction_bar_original = HUDInteraction.hide_interaction_bar
 	local show_interact_original		= HUDInteraction.show_interact
+	local remove_interact_original      = HUDInteraction.remove_interact
 	local destroy_original				= HUDInteraction.destroy
 
 	local set_interaction_bar_width_original = HUDInteraction.set_interaction_bar_width
@@ -468,6 +473,82 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudinteraction" then
 	end
 
 	function HUDInteraction:show_interact(data)
+	    local SCALE = VHUDPlus:getSetting({"INTERACTION", "TEXT_SCALE"}, 0.8)
+	    if 0 < managers.player:upgrade_level("player", "drill_speed_multiplier", 0) then
+            offset_speed = 2.25
+            offset_auto  = 1.82
+        else
+            offset_speed = 1.82		
+            offset_auto  = 2.25
+        end
+
+	    self._drill_skills_panel = self._hud_panel:panel({
+		    layer = 1,
+		    visible = true,
+		    align = "center",
+		    y = self._hud_panel:child(self._child_name_text):bottom()
+	    })
+
+	    self._drill_skills_panel:bitmap({
+		    y = 10,
+		    visible = 0 < managers.player:upgrade_level("player", "drill_speed_multiplier", 0),
+		    texture = "guis/textures/pd2/skilltree_2/icons_atlas_2",
+            texture_rect = { 3 * 80, 6 * 80, 80, 80 },
+		    color = Color.white,
+		    align = "center",
+		    w = 80 * SCALE,
+		    h = 80 * SCALE,
+		    layer = 2
+	    }):set_center_x(self._drill_skills_panel:w() / offset_speed)
+
+	    self._drill_skills_panel:bitmap({
+		    y = 10,
+		    visible = 0 < managers.player:upgrade_level("player", "drill_autorepair_2", 0),
+		    texture = "guis/textures/pd2/skilltree_2/icons_atlas_2",
+            texture_rect = { 5 * 80, 5 * 80, 80, 80 },
+		    color = Color.white,
+		    align = "center",
+		    w = 80 * SCALE,
+		    h = 80 * SCALE,
+		    layer = 2
+	    }):set_center_x(self._drill_skills_panel:w() / offset_auto)
+
+	    self._drill_skills_panel:bitmap({
+		    y = 10,
+		    visible = 0 < managers.player:upgrade_level("player", "silent_drill", 0),
+		    texture = "guis/textures/pd2/skilltree_2/icons_atlas_2",
+		    texture_rect = { 9 * 80, 6 * 80, 80, 80 },
+		    color = Color.white,
+		    align = "center",
+		    w = 80 * SCALE,
+		    h = 80 * SCALE,
+		    layer = 2
+	    }):set_center_x(self._drill_skills_panel:w() / 2 )
+
+	    if managers.player:upgrade_level("player", "silent_drill", 0) and managers.player:upgrade_level("player", "drill_autorepair_1", 0) == 1 then
+		    self._drill_skills_panel:bitmap({
+			    texture = "guis/textures/pd2/skilltree_2/ace_symbol",
+			    h = 100 * SCALE,
+			    w = 100 * SCALE,
+			    alpha = 1,
+			    blend_mode = "add",
+			    color = Color.white,
+			    layer = 1
+		    }):set_center_x(self._drill_skills_panel:w() / 2)
+	    end
+
+	    if managers.player:upgrade_level("player", "drill_speed_multiplier", 0) == 2 then
+		    self._drill_skills_panel:bitmap({
+			    texture = "guis/textures/pd2/skilltree_2/ace_symbol",
+			    h = 100 * SCALE,
+			    w = 100 * SCALE,
+			    alpha = 1,
+			    blend_mode = "add",
+			    color = Color.white,
+			    layer = 1
+		    }):set_center_x(self._drill_skills_panel:w() / offset_speed)	
+	    end
+		
 		if not VHUDPlus:getSetting({"INTERACTION", "CUSTOM_HUDS_SUPPORT"}, false) then
 			self:_rescale()
 		end
@@ -475,6 +556,18 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudinteraction" then
 			return show_interact_original(self, data)
 		end
 	end
+	
+	function HUDInteraction:show_drill_interact()
+	    self._drill_skills_panel:set_visible(true)
+    end
+	
+	function HUDInteraction:remove_interact(...)
+	    if alive(self._drill_skills_panel) then
+		    self._drill_skills_panel:set_visible(false)
+        end
+		
+	    return remove_interact_original(self, ...)
+    end	
 
 	function HUDInteraction:destroy()
 		if self._interact_time and self._hud_panel then
@@ -517,6 +610,7 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudinteraction" then
 elseif string.lower(RequiredScript) == "lib/units/interactions/interactionext" then
 	local _add_string_macros_original = BaseInteractionExt._add_string_macros
 	local _interact_blocked_original = IntimitateInteractionExt._interact_blocked
+	local selected_original          = BaseInteractionExt.selected	
 	local jokers = {}
 	
 	local function kill_joker()
@@ -600,6 +694,15 @@ elseif string.lower(RequiredScript) == "lib/units/interactions/interactionext" t
 			macros.VALUE = ""
 		end
 	end
+	
+	function BaseInteractionExt:selected(...)
+	    if selected_original(self, ...) and self._unit:base() and self._unit:base().is_drill and VHUDPlus:getSetting({"INTERACTION", "DRILL_ICONS"}, true) and not VHUDPlus:getSetting({"INTERACTION", "CUSTOM_HUDS_SUPPORT"}, false) then
+		    managers.hud:show_drill_interact()
+	    elseif selected_original(self, ...) and self._unit:base() and self._unit:base().is_saw and VHUDPlus:getSetting({"INTERACTION", "DRILL_ICONS"}, true) and not VHUDPlus:getSetting({"INTERACTION", "CUSTOM_HUDS_SUPPORT"}, false) then
+	        managers.hud:show_drill_interact()
+	    end
+	    return selected_original(self, ...)
+    end	
 
 elseif string.lower(RequiredScript) == "lib/managers/objectinteractionmanager" then
 	ObjectInteractionManager.AUTO_PICKUP_DELAY = VHUDPlus:getTweakEntry("AUTO_PICKUP_DELAY", "number", 0.2)	 --Delay in seconds between auto-pickup procs (0 -> as fast as possible)


### PR DESCRIPTION
Suggestion to add in this mod: https://modworkshop.net/mod/26626

Since its from hoxhud like a lot of other things in this hud

I made the new ace icon the only option to reduce the amount of menu options and I also took away the kickstarter option as the restart icon looks nicer.

The scaling is done through the interaction text scale and if custom hud support is enabled the icons will be disabled. The subtitles/buffs wont overlap the icons when using the default options.

Localization:

	"wolfhud_drill_icons_title" : "Show drill upgrade icons",
	"wolfhud_drill_icons_desc" : "Display active drill skills when interacting with drills/saws"