### PR TITLE
Restoration hud compatibility

### DIFF
--- a/lua/HUDChat.lua
+++ b/lua/HUDChat.lua
@@ -60,6 +60,9 @@ if RequiredScript == "lib/managers/hud/hudchat" then
 			if HUDManager.HAS_MINIMAP then
 				self._panel:move(0, -HUDMiniMap.SIZE[2])
 			end
+		elseif restoration then
+			self._panel:set_left(0)
+			self._panel:set_bottom(self._parent:h() - 200)			
 		else
 			--Default chat box position
 			self._panel:set_left(0)


### PR DESCRIPTION
The chat panel clips with the team mate panel from restoration hud, this will just move the chat panel up a bit when the mod is present