### PR TITLE
Trade delay update

### DIFF
--- a/lua/TabStats.lua
+++ b/lua/TabStats.lua
@@ -115,10 +115,10 @@ if string.lower(RequiredScript) == "lib/managers/hud/newhudstatsscreen" then
 			placer:new_row(0, 8)
 			local space = string.rep(" ", 5)
 		    local trade_delay = alive(managers.player:player_unit()) and managers.groupai:state():all_criminals()[managers.player:player_unit():key()] and managers.groupai:state():all_criminals()[managers.player:player_unit():key()].respawn_penalty
-			local delay = trade_delay and managers.localization:text("hud_trade_delay", {TIME = tostring(self:_trade_delay_time(trade_delay))}) .. space .. " | " .. space or ""		
+			local delay = trade_delay and space .. " | " .. space .. managers.localization:text("hud_trade_delay", {TIME = tostring(self:_trade_delay_time(trade_delay))}) or ""		
 		
 			local track_text = placer:add_bottom(ext_inv_panel:fine_text({
-				text = delay .. managers.localization:to_upper_text("menu_es_playing_track") .. " " .. managers.music:current_track_string(),
+				text = managers.localization:to_upper_text("menu_es_playing_track") .. " " .. managers.music:current_track_string() .. delay,
 				font_size = small_font_size,
 				font = 15,
 				color = tweak_data.screen_colors.text,

--- a/lua/TabStats.lua
+++ b/lua/TabStats.lua
@@ -113,15 +113,16 @@ if string.lower(RequiredScript) == "lib/managers/hud/newhudstatsscreen" then
 			}), 7)
 
 			placer:new_row(0, 8)
+			local space = string.rep(" ", 5)
 		    local trade_delay = alive(managers.player:player_unit()) and managers.groupai:state():all_criminals()[managers.player:player_unit():key()] and managers.groupai:state():all_criminals()[managers.player:player_unit():key()].respawn_penalty
-			local delay = trade_delay and managers.localization:text("hud_trade_delay", {TIME = tostring(self:_trade_delay_time(trade_delay))}) or ""	
+			local delay = trade_delay and managers.localization:text("hud_trade_delay", {TIME = tostring(self:_trade_delay_time(trade_delay))}) .. space .. " | " .. space or ""		
 		
 			local track_text = placer:add_bottom(ext_inv_panel:fine_text({
-				text = delay .. " " .. " | " .. " " .. managers.localization:to_upper_text("menu_es_playing_track") .. " " .. managers.music:current_track_string(),
+				text = delay .. managers.localization:to_upper_text("menu_es_playing_track") .. " " .. managers.music:current_track_string(),
 				font_size = small_font_size,
-				font = small_font,
+				font = 15,
 				color = tweak_data.screen_colors.text,
-				align = "right",
+				align = "left",
 				keep_w = true
 			}))
 


### PR DESCRIPTION
Made the font a bit smaller to make sure the delay text and song text both would fit.
![text](https://user-images.githubusercontent.com/30779314/75312197-7ebef980-5859-11ea-85ad-3f615f4cd6b4.png)

Moved the text from the left side to the right to make it look better and also added some space between the song and trade delay texts.

No civs killed
![newtwo](https://user-images.githubusercontent.com/30779314/75312251-a2823f80-5859-11ea-8113-933ed4df29cb.png)

After civs killed
![newone](https://user-images.githubusercontent.com/30779314/75312266-a9a94d80-5859-11ea-82e8-22f94e84660f.png)

Update moved trade delay to the back
![newer](https://user-images.githubusercontent.com/30779314/75312636-d6119980-585a-11ea-825e-02698f3391cf.png)


