### PR TITLE
Hud scaling Updated

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -226,6 +226,7 @@ if not _G.VHUDPlus then
 					},
 				},
 				USE_REAL_AMMO 						= true,
+				HUD_SCALE 						    = 1,				
 			},
 			MISCHUD = {
 				ENABLE_IFBG							= false,

--- a/Core.lua
+++ b/Core.lua
@@ -393,7 +393,7 @@ if not _G.VHUDPlus then
 				},
 				BUFF_LIST = {
 					show_buffs 								= true,     --Active effects (buffs/debuffs). Also see HUDList.BuffItemBase.IGNORED_BUFFS table to ignore specific buffs that you don't want listed, or enable some of those not shown by default
-					show_subtitles                          = true,					
+					show_subtitles                          = false,					
 					damage_increase							= true,
 					damage_reduction						= true,
 					melee_damage_increase					= true,

--- a/Core.lua
+++ b/Core.lua
@@ -393,6 +393,7 @@ if not _G.VHUDPlus then
 				},
 				BUFF_LIST = {
 					show_buffs 								= true,     --Active effects (buffs/debuffs). Also see HUDList.BuffItemBase.IGNORED_BUFFS table to ignore specific buffs that you don't want listed, or enable some of those not shown by default
+					show_subtitles                          = true,					
 					damage_increase							= true,
 					damage_reduction						= true,
 					melee_damage_increase					= true,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -447,7 +447,8 @@ if VHUDPlus then
 						desc_id = "wolfhud_hud_scale_desc",
 						visible_reqs = {},
 						enabled_reqs = {
-						    { setting = {"CustomHUD", "ENABLED"}, invert = false }
+						    { setting = {"CustomHUD", "ENABLED"}, invert = false },
+							{ setting = {"HUDList", "BUFF_LIST", "show_subtitles"}, invert = true },
 						},
 						value = {"CustomHUD", "HUD_SCALE"},
 						min_value = 0.5,
@@ -2475,6 +2476,21 @@ if VHUDPlus then
 								visible_reqs = {},
 								enabled_reqs = {
 									{ setting = { "HUDList", "ENABLED" }, invert = false },
+								},
+							},
+							{
+								type = "divider",
+								size = 8,
+							},
+							{
+								type = "toggle",
+								name_id = "wolfhud_hudlist_show_subtitles_title",
+								desc_id = "wolfhud_hudlist_show_subtitles_desc",
+								value = {"HUDList", "BUFF_LIST", "show_subtitles"},
+								visible_reqs = {},
+								enabled_reqs = {
+									{ setting = { "HUDList", "ENABLED" }, invert = false },
+									{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
 								},
 							},
 							{

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -436,6 +436,23 @@ if VHUDPlus then
 						desc_id = "wolfhud_use_vanillahud_extra_desc",
 						value = {"CustomHUD", "ENABLED"},
 						visible_reqs = {}, enabled_reqs = {},
+	                                },
+					{
+						type = "divider",
+						size = 8,
+					},
+					{
+					    type = "slider",
+						name_id = "wolfhud_hud_scale_title",
+						desc_id = "wolfhud_hud_scale_desc",
+						visible_reqs = {},
+						enabled_reqs = {
+						    { setting = {"CustomHUD", "ENABLED"}, invert = false }
+						},
+						value = {"CustomHUD", "HUD_SCALE"},
+						min_value = 0.5,
+						max_value = 1,
+						step_size = 0.05,							
 					},
 					{
 						type = "divider",

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -145,7 +145,7 @@ if RequiredScript == "lib/managers/hudmanagerpd2" then
 		self:_create_waiting_legend(hud)
 	end
 
-    if not  VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "show_subtitles"}, true) then
+    if not  VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "show_subtitles"}, false) then
         scale = VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1)
     else
         scale = 1

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -122,6 +122,46 @@ if RequiredScript == "lib/managers/hudmanagerpd2" then
 
 		return update_original(self, ...)
 	end
+	
+	Hooks:PreHook(HUDManager, "_setup_player_info_hud_pd2", "wolfhud_scaling", function(self)
+    	managers.gui_data:layout_scaled_fullscreen_workspace(managers.hud._saferect)
+	end)
+
+	function HUDManager:recreate_player_info_hud_pd2()
+		if not self:alive(PlayerBase.PLAYER_INFO_HUD_PD2) then return end
+		local hud = managers.hud:script(PlayerBase.PLAYER_INFO_HUD_PD2)
+		self:_create_present_panel(hud)
+		self:_create_interaction(hud)
+		self:_create_progress_timer(hud)
+		self:_create_objectives(hud)
+		self:_create_hint(hud)
+		self:_create_heist_timer(hud)
+		self:_create_temp_hud(hud)
+		self:_create_suspicion(hud)
+		self:_create_hit_confirm(hud)
+		self:_create_hit_direction(hud)
+		self:_create_downed_hud()
+		self:_create_custody_hud()
+		self:_create_waiting_legend(hud)
+	end
+
+	core:module("CoreGuiDataManager")
+	function GuiDataManager:layout_scaled_fullscreen_workspace(ws)
+	    local base_res = {x = 1280, y = 720}
+	    local res = RenderSettings.resolution
+	    local sc = (2 - _G.VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1))
+	    local aspect_width = base_res.x / self:_aspect_ratio()
+	    local h = math.round(sc * math.max(base_res.y, aspect_width))
+	    local w = math.round(sc * math.max(base_res.x, aspect_width / h))
+
+	    local safe_w = math.round(0.95 * res.x)
+	    local safe_h = math.round(0.95 * res.y)   
+	    local sh = math.min(safe_h, safe_w / (w / h))
+	    local sw = math.min(safe_w, safe_h * (w / h))
+	    local x = res.x / 2 - sh * (w / h) / 2
+	    local y = res.y / 2 - sw / (w / h) / 2
+	    ws:set_screen(w, h, x, y, math.min(sw, sh * (w / h)))
+	end	
 
 elseif RequiredScript == "lib/managers/hud/hudteammate" then
 

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -145,11 +145,17 @@ if RequiredScript == "lib/managers/hudmanagerpd2" then
 		self:_create_waiting_legend(hud)
 	end
 
+    if not  VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "show_subtitles"}, false) then
+        scale = VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1)
+    else
+        scale = 1
+    end	
+
 	core:module("CoreGuiDataManager")
 	function GuiDataManager:layout_scaled_fullscreen_workspace(ws)
 	    local base_res = {x = 1280, y = 720}
 	    local res = RenderSettings.resolution
-	    local sc = (2 - _G.VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1))
+	    local sc = (2 - _G.scale)
 	    local aspect_width = base_res.x / self:_aspect_ratio()
 	    local h = math.round(sc * math.max(base_res.y, aspect_width))
 	    local w = math.round(sc * math.max(base_res.x, aspect_width / h))

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -145,7 +145,7 @@ if RequiredScript == "lib/managers/hudmanagerpd2" then
 		self:_create_waiting_legend(hud)
 	end
 
-    if not  VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "show_subtitles"}, false) then
+    if not  VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "show_subtitles"}, true) then
         scale = VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1)
     else
         scale = 1


### PR DESCRIPTION
Had an idea that might be a bit out there but I thought that the ability to scale the hud down was really nice.

Update: After some more testing around using all the various options I discovered that there was a problem with the subtitle display when using this and the buffs at the same time. I don't know if that's something that can easily be fixed but I added a new option to the buff list that will show the subtitles and default the hud scale to normal.

  

localization: 

	"wolfhud_hud_scale_title" : "Hud Scale",
	"wolfhud_hud_scale_desc" : "Change the size of the hud (Disabled if buff subtitles is enabled)",
	"wolfhud_hudlist_show_subtitles_title" : "Show subtitles",
	"wolfhud_hudlist_show_subtitles_desc" : "Show subtitles above the buffs (Will set the hud scale as default)"

I used this mod to add this:
https://modworkshop.net/mod/20849