### PR TITLE
New hud scale

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -226,6 +226,7 @@ if not _G.VHUDPlus then
 					},
 				},
 				USE_REAL_AMMO 						= true,
+				HUD_SCALE 						    = 1,				
 			},
 			MISCHUD = {
 				ENABLE_IFBG							= false,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -441,6 +441,23 @@ if VHUDPlus then
 						type = "divider",
 						size = 8,
 					},
+					{
+					    type = "slider",
+						name_id = "wolfhud_hud_scale_title",
+						desc_id = "wolfhud_hud_scale_desc",
+						visible_reqs = {},
+						enabled_reqs = {
+						    { setting = {"CustomHUD", "ENABLED"}, invert = false },
+						},
+						value = {"CustomHUD", "HUD_SCALE"},
+						min_value = 0.5,
+						max_value = 1,
+						step_size = 0.05,						
+					},
+					{						
+						type = "divider",
+						size = 8,
+					},
 					{	--CustomHUD Player
 						type = "menu",
 						menu_id = "wolfhud_customhud_player_options_menu",

--- a/lua/DrivingHUD.lua
+++ b/lua/DrivingHUD.lua
@@ -61,6 +61,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 		self._name = ""
 		self._markers = {}
 		local x_pos, y_pos
+		
 		if pdth_hud and pdth_hud.Options:GetValue("HUD/MainHud") then
 			y_pos = -90
 			x_pos = 500
@@ -68,42 +69,43 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			y_pos = -230
 			x_pos = 540
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.55 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 900
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.60 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 875
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.65 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 840		
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.70 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 800
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.75 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 775
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.80 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 740
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.85 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 700
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.90 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 675
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 640
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 600			
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) then
-			y_pos = -140
+			y_pos = -160
 			x_pos = 575
 		else 
 			y_pos = -140
 			x_pos = 540
 		end
+		
 		self._people = 0
 		self.drivingpanel = self._hud_panel:panel({
 			w = self._hud_panel:w(),
@@ -304,6 +306,44 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 		local car_texture_rect = { 1024, 0, 512, 512}
 		local car_texture = "assets/guis/textures/contact_vlad"
 		
+		if VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.55 then
+			vy_pos = 920
+			vx_pos = 780
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.60 then
+			vy_pos = 890
+			vx_pos = 750
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.65 then
+			vy_pos = 850
+			vx_pos = 720
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.70 then
+			vy_pos = 820
+			vx_pos = 690
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.75 then
+			vy_pos = 780
+			vx_pos = 660
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.80 then
+			vy_pos = 750
+			vx_pos = 620
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.85 then
+			vy_pos = 720
+			vx_pos = 590
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.90 then
+			vy_pos = 680
+			vx_pos = 560
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
+			vy_pos = 640
+			vx_pos = 530
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
+			vy_pos = 600
+			vx_pos = 500				
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) then
+			vy_pos = 575
+			vx_pos = 465
+		else 
+			vy_pos = 530
+			vx_pos = 420
+		end		
+		
 		local vis = VHUDPlus:getSetting({"DrivingHUD", "SHOW_VEHICLE"}, true)
 		local vehicle_bitmap = self.drivingpanel:bitmap({
 			vertical = "bottom",
@@ -314,8 +354,8 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 			layer = 1,
 			texture = car_texture,
 			texture_rect = car_texture_rect,
-			x = x_pos + 420,
-			y = y_pos + 530,
+			x = x_pos + vx_pos,
+			y = y_pos + vy_pos,
 			w = 180,
 			h = 180
 		})

--- a/lua/DrivingHUD.lua
+++ b/lua/DrivingHUD.lua
@@ -67,7 +67,40 @@ if string.lower(RequiredScript) == "lib/managers/hud/huddriving" then
 		elseif mod_collection then
 			y_pos = -230
 			x_pos = 540
-		else
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.55 then
+			y_pos = -140
+			x_pos = 900
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.60 then
+			y_pos = -140
+			x_pos = 875
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.65 then
+			y_pos = -140
+			x_pos = 840		
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.70 then
+			y_pos = -140
+			x_pos = 800
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.75 then
+			y_pos = -140
+			x_pos = 775
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.80 then
+			y_pos = -140
+			x_pos = 740
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.85 then
+			y_pos = -140
+			x_pos = 700
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.90 then
+			y_pos = -140
+			x_pos = 675
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
+			y_pos = -140
+			x_pos = 640
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
+			y_pos = -140
+			x_pos = 600			
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) then
+			y_pos = -140
+			x_pos = 575
+		else 
 			y_pos = -140
 			x_pos = 540
 		end

--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -745,10 +745,34 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 			y = hud_panel:bottom() - ((HUDListManager.ListOptions.buff_list_height_offset or 90) + list_height)
 		end
 
+		if VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.55 then
+		sub_offset = 375
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.60 then
+		sub_offset = 330
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.65 then
+		sub_offset = 300
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.70 then
+		sub_offset = 275
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.75 then
+		sub_offset = 230
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.80 then
+		sub_offset = 200
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.85 then
+		sub_offset = 175
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.90 then
+		sub_offset = 130
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
+		sub_offset = 100
+		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
+		sub_offset = 60
+		else
+		sub_offset = 30
+		end
+
 		if managers.subtitle then
 			local sub_presenter = managers.subtitle:presenter()
 			if sub_presenter and sub_presenter.set_bottom then
-				sub_presenter:set_bottom(y - 30)
+				sub_presenter:set_bottom(y - sub_offset)
 			end
 		end
 

--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -766,7 +766,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
 		sub_offset = 60
 		else
-		sub_offset = 30
+		sub_offset = 35
 		end
 
 		if managers.subtitle then

--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -764,7 +764,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
 		sub_offset = 100
 		elseif VHUDPlus:getSetting({"CustomHUD", "ENABLED"}, true) and VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
-		sub_offset = 60
+		sub_offset = 65
 		else
 		sub_offset = 35
 		end

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -122,6 +122,46 @@ if RequiredScript == "lib/managers/hudmanagerpd2" then
 
 		return update_original(self, ...)
 	end
+	
+	Hooks:PreHook(HUDManager, "_setup_player_info_hud_pd2", "wolfhud_scaling", function(self)
+    	managers.gui_data:layout_scaled_fullscreen_workspace(managers.hud._saferect)
+	end)
+
+	function HUDManager:recreate_player_info_hud_pd2()
+		if not self:alive(PlayerBase.PLAYER_INFO_HUD_PD2) then return end
+		local hud = managers.hud:script(PlayerBase.PLAYER_INFO_HUD_PD2)
+		self:_create_present_panel(hud)
+		self:_create_interaction(hud)
+		self:_create_progress_timer(hud)
+		self:_create_objectives(hud)
+		self:_create_hint(hud)
+		self:_create_heist_timer(hud)
+		self:_create_temp_hud(hud)
+		self:_create_suspicion(hud)
+		self:_create_hit_confirm(hud)
+		self:_create_hit_direction(hud)
+		self:_create_downed_hud()
+		self:_create_custody_hud()
+		self:_create_waiting_legend(hud)
+	end
+
+	core:module("CoreGuiDataManager")
+	function GuiDataManager:layout_scaled_fullscreen_workspace(ws)
+	    local base_res = {x = 1280, y = 720}
+	    local res = RenderSettings.resolution
+	    local sc = (2 - _G.VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1))
+	    local aspect_width = base_res.x / self:_aspect_ratio()
+	    local h = math.round(sc * math.max(base_res.y, aspect_width))
+	    local w = math.round(sc * math.max(base_res.x, aspect_width / h))
+
+	    local safe_w = math.round(0.95 * res.x)
+	    local safe_h = math.round(0.95 * res.y)   
+	    local sh = math.min(safe_h, safe_w / (w / h))
+	    local sw = math.min(safe_w, safe_h * (w / h))
+	    local x = res.x / 2 - sh * (w / h) / 2
+	    local y = res.y / 2 - sw / (w / h) / 2
+	    ws:set_screen(w, h, x, y, math.min(sw, sh * (w / h)))
+	end	
 
 elseif RequiredScript == "lib/managers/hud/hudteammate" then
 


### PR DESCRIPTION
Remade the hud scaling so it would change the subtitle offset for the buffs depending on the current hud scale setting instead of a bunch of new confusing options.

It is compatible with other huds like restoration and holo and will simply take priority when extra hud settings is enabled.

For other huds like void ui the scaling will be done through both mods as long as you are using the vanilla hud from this mod otherwise all scaling will be done through the other hud.

Updated to make sure the driving hud will scale correctly

localization:

"wolfhud_hud_scale_title" : "Hud Scale",
"wolfhud_hud_scale_desc" : "Change the size of the hud"