### PR TITLE
Updated version number and loc

### DIFF
--- a/WolfHUDTweakData.lua
+++ b/WolfHUDTweakData.lua
@@ -61,7 +61,7 @@ function WolfHUDTweakData:init()
 		secondary_deployable 	-> The eqipped secondary deployable (in case of Jack of all trades)
 --]]
 	self.STD_LOBBY_LOADOUT_LAYOUT = {
-										{ "playtime", "ping" },
+										{ "playtime" },
 										{ "name" },
 										{ "character" },
 										{ "skills" },
@@ -73,7 +73,7 @@ function WolfHUDTweakData:init()
 										{ "deployable", "secondary_deployable" }
 									}
 	self.CS_LOBBY_LOADOUT_LAYOUT = {
-										{ "playtime", "ping" },
+										{ "playtime" },
 										{ "name" },
 										{ "skills" },
 										{ "perk" },

--- a/loc/chinese.json
+++ b/loc/chinese.json
@@ -1114,5 +1114,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"	
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"	
 }

--- a/loc/english.json
+++ b/loc/english.json
@@ -1116,5 +1116,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/loc/french.json
+++ b/loc/french.json
@@ -1112,5 +1112,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/loc/german.json
+++ b/loc/german.json
@@ -1123,5 +1123,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/loc/korean.json
+++ b/loc/korean.json
@@ -1116,5 +1116,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/loc/portuguese.json
+++ b/loc/portuguese.json
@@ -1119,5 +1119,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/loc/russian.json
+++ b/loc/russian.json
@@ -1116,5 +1116,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/loc/spanish.json
+++ b/loc/spanish.json
@@ -1116,5 +1116,7 @@
 	"wolfhud_enemy_escort_it_guy" : "Bank IT Guy",
 	"wolfhud_hudlist_loot_egg" : "Egg",
 	"wolfhud_hudlist_loot_treasure" : "Treasure",
-	"wolfhud_enemy_mariachi" : "Mariachi Band Member"
+	"wolfhud_enemy_mariachi" : "Mariachi Band Member",
+    "wolfhud_hud_scale_title" : "Hud Scale",
+    "wolfhud_hud_scale_desc" : "Change the size of the hud"
 }

--- a/mod.txt
+++ b/mod.txt
@@ -2,7 +2,7 @@
 	"name" : "Vanilla HUD Plus",
 	"description" : "This is a Mod Collection of HUD altering scripts, as well as quality of life changes to the game and its menus",
 	"author" : "Kamikaze94, BangL, Test1, LT71 (Bunnie( 2))",
-	"version" : "1.50",
+	"version" : "1.60",
 	"priority" : 150,
 	"blt_version" : 2,
 	"hooks" : [


### PR DESCRIPTION
Changed version number from 1.50 to 1.60

Added some localization

Took out the ping display from the crew loadout in the lobby. I did this because the ping display won't update unless you have the ping option enabled and if you do have it enabled it appears above the player name and you don't need 2 ping displays.