### PR TITLE
Joker label options

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -237,9 +237,7 @@ if not _G.VHUDPlus then
 				JOKER_CONTOUR                       = true,
 				INSPIRE_HINT                        = false,				
                 SCALE                               = 1,
-				SUB				                    = false,
-				ENABLE_JOKER_FLOATING_NAME			= true,
-				ENABLE_JOKER_FLOATING_HP			= true,	
+				SUB				                    = false,	
 			},
 			HUDChat = {
 				ENABLED									= true,
@@ -504,6 +502,9 @@ if not _G.VHUDPlus then
 				SHOW_ECMS								= false,
 				SHOW_TIMERS			 					= true,
 				SHOW_MINIONS							= true,
+				ENABLE_JOKER_FLOATING_NAME			    = true,
+				ENABLE_JOKER_FLOATING_HP			    = true,
+				ENABLE_JOKER_FLOATING_KILLS			    = true,				
 				SHOW_PAGER								= false,
 				SHOW_SPECIAL_EQUIPMENT					= false,
 				LOOT = {

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1008,20 +1008,6 @@ if VHUDPlus then
 								max_value = 1.2,
 								step_size = 0.05,						
 							},
-							{
-								type = "toggle",
-								name_id = "wolfhud_enable_joker_floating_name_title",
-								desc_id = "wolfhud_enable_joker_floating_name_desc",
-								visible_reqs = {}, enabled_reqs = {},
-								value = {"MISCHUD", "ENABLE_JOKER_FLOATING_NAME"},
-							},
-							{
-								type = "toggle",
-								name_id = "wolfhud_enable_joker_floating_hp_title",
-								desc_id = "wolfhud_enable_joker_floating_hp_desc",
-								visible_reqs = {}, enabled_reqs = {},
-								value = {"MISCHUD", "ENABLE_JOKER_FLOATING_HP"},
-							},
 						},
 					},
 					{
@@ -3529,11 +3515,38 @@ if VHUDPlus then
 						visible_reqs = {}, enabled_reqs = {},
 					},
 					{
+						type = "divider",
+						size = 8,						
+					},
+					{
 						type = "toggle",
 						name_id = "wolfhud_waypoints_show_minions_title",
 						desc_id = "wolfhud_waypoints_show_minions_desc",
 						value = {"CustomWaypoints", "SHOW_MINIONS"},
 						visible_reqs = {}, enabled_reqs = {},
+						visible_reqs = {}, enabled_reqs = {},
+					},
+					{
+						type = "toggle",
+						name_id = "wolfhud_enable_joker_floating_name_title",
+						desc_id = "wolfhud_enable_joker_floating_name_desc",
+						visible_reqs = {
+						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },
+						}, enabled_reqs = {
+						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
+						},
+						value = {"MISCHUD", "ENABLE_JOKER_FLOATING_NAME"},
+					},
+					{
+						type = "toggle",
+						name_id = "wolfhud_enable_joker_floating_hp_title",
+						desc_id = "wolfhud_enable_joker_floating_hp_desc",
+						visible_reqs = {
+						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
+						}, enabled_reqs = {
+						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
+						},
+						value = {"MISCHUD", "ENABLE_JOKER_FLOATING_HP"},						
 					},
 					{
 						type = "divider",

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -3546,7 +3546,18 @@ if VHUDPlus then
 						}, enabled_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
 						},
-						value = {"MISCHUD", "ENABLE_JOKER_FLOATING_HP"},						
+						value = {"MISCHUD", "ENABLE_JOKER_FLOATING_HP"},
+					},
+					{
+						type = "toggle",
+						name_id = "wolfhud_enable_joker_floating_kills_title",
+						desc_id = "wolfhud_enable_joker_floating_kills_desc",
+						visible_reqs = {
+						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },
+						}, enabled_reqs = {
+						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
+						},
+						value = {"CustomHUD", "ENABLE_JOKER_FLOATING_KILLS"},						
 					},
 					{
 						type = "divider",

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -3530,34 +3530,34 @@ if VHUDPlus then
 						type = "toggle",
 						name_id = "wolfhud_enable_joker_floating_name_title",
 						desc_id = "wolfhud_enable_joker_floating_name_desc",
+						value = {"CustomWaypoints", "ENABLE_JOKER_FLOATING_NAME"},						
 						visible_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },
 						}, enabled_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
 						},
-						value = {"MISCHUD", "ENABLE_JOKER_FLOATING_NAME"},
 					},
 					{
 						type = "toggle",
 						name_id = "wolfhud_enable_joker_floating_hp_title",
 						desc_id = "wolfhud_enable_joker_floating_hp_desc",
+						value = {"CustomWaypoints", "ENABLE_JOKER_FLOATING_HP"},						
 						visible_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
 						}, enabled_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
 						},
-						value = {"MISCHUD", "ENABLE_JOKER_FLOATING_HP"},
 					},
 					{
 						type = "toggle",
 						name_id = "wolfhud_enable_joker_floating_kills_title",
 						desc_id = "wolfhud_enable_joker_floating_kills_desc",
+						value = {"CustomWaypoints", "ENABLE_JOKER_FLOATING_KILLS"},						
 						visible_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },
 						}, enabled_reqs = {
 						    { setting = {"CustomWaypoints", "SHOW_MINIONS"}, invert = false },						
-						},
-						value = {"CustomHUD", "ENABLE_JOKER_FLOATING_KILLS"},						
+						},						
 					},
 					{
 						type = "divider",

--- a/lua/CustomWaypoints.lua
+++ b/lua/CustomWaypoints.lua
@@ -525,7 +525,7 @@ if RequiredScript == "lib/managers/hudmanager" then
 				scale = 1.25,
 				health_bar = {
 					type = "icon",
-					show = true,
+					show = VHUDPlus:getSetting({"CustomWaypoints", "ENABLE_JOKER_FLOATING_HP"}),
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_health",
 					--texture_rect = {0, 0, 64, 64},
@@ -534,7 +534,7 @@ if RequiredScript == "lib/managers/hudmanager" then
 				},
 				health_shield = {
 					type = "icon",
-					show = true,
+					show = VHUDPlus:getSetting({"CustomWaypoints", "ENABLE_JOKER_FLOATING_HP"}),
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_shield",
 					--texture_rect = {0, 0, 64, 64},
@@ -543,14 +543,14 @@ if RequiredScript == "lib/managers/hudmanager" then
 				},
 				health_bg = {
 					type = "icon",
-					show = true,
+					show = VHUDPlus:getSetting({"CustomWaypoints", "ENABLE_JOKER_FLOATING_HP"}),
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_radialbg",
 					--texture_rect = {0, 0, 64, 64},
 				},
 				health_dmg = {
 					type = "icon",
-					show = true,
+					show = VHUDPlus:getSetting({"CustomWaypoints", "ENABLE_JOKER_FLOATING_HP"}),
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_radial_rim",
 					--texture_rect = {0, 0, 64, 64},
@@ -559,12 +559,12 @@ if RequiredScript == "lib/managers/hudmanager" then
 				},
 				name = {
 					type = "label",
-					show = true,
+					show = VHUDPlus:getSetting({"CustomWaypoints", "ENABLE_JOKER_FLOATING_NAME"}),
 					text = VHUDPlus:getCharacterName(unit_tweak, true)
 				},
 				kills = {
 					type = "label",
-					show = true,
+					show = VHUDPlus:getSetting({"CustomWaypoints", "ENABLE_JOKER_FLOATING_KILLS"}),
 					text = string.format("%s %d", utf8.char(57364), data.kills or 0),
 					color = Color.white,
 					alpha = 0.8,


### PR DESCRIPTION
I went ahead and expanded on the options to hide parts of the joker labels/health.

Added option to hide killcount and moved the options to the waypoints menu.

localization for kill option:

	"wolfhud_enable_joker_floating_kills_title" : "Enable Joker Kills",
	"wolfhud_enable_joker_floating_kills_desc" : "Shows joker Kills above them."