### PR TITLE
Damage glow text color and civ option

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -289,6 +289,7 @@ if not _G.VHUDPlus then
 				HEADSHOT_COLOR							= "red",
 				CRITICAL_COLOR 							= "light_purple",
 				SHOW_DAMAGE_POPUP_ALT					= true,
+				SHOW_DAMAGE_POPUP_ALT_CIV               = true,				
 				GLOW_COLOR 								= "yellow",
 			},
 			AssaultBanner = {

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1688,6 +1688,18 @@ if VHUDPlus then
 								value = {"DamagePopup", "SHOW_DAMAGE_POPUP_ALT"},
 							},
 							{
+								type = "toggle",
+								name_id = "wolfhud_dmg_popup_show_alt_civ_popup_title",
+								desc_id = "wolfhud_dmg_popup_show_alt_civ_popup_desc",
+								visible_reqs = {
+								    { setting = { "DamagePopup", "SHOW_DAMAGE_POPUP_ALT" }, invert = false }
+								},
+								enabled_reqs = {
+									{ setting = { "DamagePopup", "SHOW_DAMAGE_POPUP_ALT" }, invert = false },
+								},
+								value = {"DamagePopup", "SHOW_DAMAGE_POPUP_ALT_CIV"},								
+							},
+							{
 								type = "multi_choice",
 								name_id = "wolfhud_dmg_popup_headshot_glow_color_title",
 								desc_id = "wolfhud_dmg_popup_headshot_glow_color_desc",

--- a/loc/chinese.json
+++ b/loc/chinese.json
@@ -1130,5 +1130,5 @@
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
 	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
 	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
-	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."	
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/chinese.json
+++ b/loc/chinese.json
@@ -1128,5 +1128,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"	
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."	
 }

--- a/loc/english.json
+++ b/loc/english.json
@@ -1130,5 +1130,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/french.json
+++ b/loc/french.json
@@ -1125,6 +1125,7 @@
 	"wolfhud_enable_swan_song_effect_desc" : "The screen will flash blue when going into swan song.",
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
-	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/french.json
+++ b/loc/french.json
@@ -1125,6 +1125,7 @@
 	"wolfhud_enable_swan_song_effect_desc" : "The screen will flash blue when going into swan song.",
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
+	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",	
 	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
 	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
 	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."

--- a/loc/german.json
+++ b/loc/german.json
@@ -1137,5 +1137,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/korean.json
+++ b/loc/korean.json
@@ -1130,5 +1130,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/portuguese.json
+++ b/loc/portuguese.json
@@ -1133,5 +1133,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/russian.json
+++ b/loc/russian.json
@@ -1130,5 +1130,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/loc/spanish.json
+++ b/loc/spanish.json
@@ -1130,5 +1130,7 @@
 	"wolfhud_enable_kingpin_effect_title" : "Kingpin Injector Effect",
 	"wolfhud_enable_kingpin_effect_desc" : "The screen will flash orange when the kingpin injector is active.",
 	"wolfhud_enemy_deathvox_light" : "ZEAL Unit",
-	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL"
+	"wolfhud_enemy_deathvox_heavy" : "Heavy ZEAL",
+	"wolfhud_dmg_popup_show_alt_civ_popup_title" : "Show Civillian Damage Popup",
+	"wolfhud_dmg_popup_show_alt_civ_popup_desc" : "Enables civillian damage popup."
 }

--- a/lua/DamagePopup.lua
+++ b/lua/DamagePopup.lua
@@ -272,7 +272,7 @@ elseif RequiredScript == "lib/units/civilians/civiliandamage" then
 	self._uws:set_billboard( self._uws.BILLBOARD_BOTH )
 	
 	local panel = self._uws:panel():panel({
-		visible =  VHUDPlus:getSetting({"DamagePopup", "SHOW_DAMAGE_POPUP_ALT"}, true),
+		visible = VHUDPlus:getSetting({"DamagePopup", "SHOW_DAMAGE_POPUP_ALT"}, true) and VHUDPlus:getSetting({"DamagePopup", "SHOW_DAMAGE_POPUP_ALT_CIV"}, true),
 		name 	= "damage_panel",
 		layer = 0,
 		alpha = 0

--- a/lua/DamagePopup.lua
+++ b/lua/DamagePopup.lua
@@ -296,7 +296,7 @@ elseif RequiredScript == "lib/units/civilians/civiliandamage" then
 	
 	if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
 		local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
-		local c = tweak_data.chat_colors[ peer_id ]
+		local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
 		text:set_color( c )
 	end
 	

--- a/lua/DamagePopup.lua
+++ b/lua/DamagePopup.lua
@@ -82,7 +82,7 @@ if RequiredScript == "lib/units/enemies/cop/copdamage" then
 	
 	--if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
 		--local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
-		--local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
+		--local c = tweak_data.chat_colors[ peer_id ]
 		--text:set_color( c )
 	--end
 	
@@ -296,7 +296,7 @@ elseif RequiredScript == "lib/units/civilians/civiliandamage" then
 	
 	--if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
 		--local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
-		--local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
+		--local c = tweak_data.chat_colors[ peer_id ]
 		--text:set_color( c )
 	--end
 	

--- a/lua/DamagePopup.lua
+++ b/lua/DamagePopup.lua
@@ -82,7 +82,7 @@ if RequiredScript == "lib/units/enemies/cop/copdamage" then
 	
 	if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
 		local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
-		local c = tweak_data.chat_colors[ peer_id ]
+		local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
 		text:set_color( c )
 	end
 	

--- a/lua/DamagePopup.lua
+++ b/lua/DamagePopup.lua
@@ -71,20 +71,20 @@ if RequiredScript == "lib/units/enemies/cop/copdamage" then
 		vertical 	= "bottom",
 		font 		= tweak_data.menu.pd2_large_font,
 		font_size 	= 70,
-		color 		= Color.white
+		color 		= VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
 	})
 	
-	local attacker_unit = damage_info and damage_info.attacker_unit
+	--local attacker_unit = damage_info and damage_info.attacker_unit
 	
-	if alive( attacker_unit ) and attacker_unit:base() and attacker_unit:base().thrower_unit then
-		attacker_unit = attacker_unit:base():thrower_unit()
-	end
+	--if alive( attacker_unit ) and attacker_unit:base() and attacker_unit:base().thrower_unit then
+		--attacker_unit = attacker_unit:base():thrower_unit()
+	--end
 	
-	if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
-		local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
-		local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
-		text:set_color( c )
-	end
+	--if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
+		--local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
+		--local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
+		--text:set_color( c )
+	--end
 	
 	local body = damage_info.col_ray and damage_info.col_ray.body or self._sync_ibody_popup and self._unit:body(self._sync_ibody_popup)
 	local headshot = body and self.is_head and self:is_head(body) or false
@@ -285,20 +285,20 @@ elseif RequiredScript == "lib/units/civilians/civiliandamage" then
 		vertical 	= "bottom",
 		font 		= tweak_data.menu.pd2_large_font,
 		font_size 	= 70,
-		color 		= Color.white
+		color 		= VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
 	})
 	
-	local attacker_unit = damage_info and damage_info.attacker_unit
+	--local attacker_unit = damage_info and damage_info.attacker_unit
 	
-	if alive( attacker_unit ) and attacker_unit:base() and attacker_unit:base().thrower_unit then
-		attacker_unit = attacker_unit:base():thrower_unit()
-	end
+	--if alive( attacker_unit ) and attacker_unit:base() and attacker_unit:base().thrower_unit then
+		--attacker_unit = attacker_unit:base():thrower_unit()
+	--end
 	
-	if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
-		local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
-		local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
-		text:set_color( c )
-	end
+	--if attacker_unit and managers.network:session() and managers.network:session():peer_by_unit( attacker_unit ) then
+		--local peer_id = managers.network:session():peer_by_unit( attacker_unit ):id()
+		--local c = VHUDPlus:getColorSetting({"DamagePopup", "COLOR"}, "yellow")
+		--text:set_color( c )
+	--end
 	
 	if damage_info.result.type == "death" then
 		text:set_text( managers.localization:get_default_macro( "BTN_SKULL" ) .. text:text() )


### PR DESCRIPTION
Instead of having the glow text color be coded to the player color it can be changed in the color options.
bodyshot color will decide this.
Also gave it an option to disable the popup for killed civs.

Example of how it could look with this:
![Untitled](https://user-images.githubusercontent.com/30779314/78062166-8d378e00-738e-11ea-8740-ece87eb5aa90.png)

Hard to get a good example picture but it makes the glow match the text very nicely.

Another example pic:
![Untitled](https://user-images.githubusercontent.com/30779314/78062649-47c79080-738f-11ea-9de2-385bd6e34bc9.png)
