### PR TITLE
Disable non functional buffs

### DIFF
--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -3012,17 +3012,17 @@ if VHUDPlus then
 											{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
 										},
 									},
-									{
-										type = "toggle",
-										name_id = "wolfhud_hudlist_unseen_strike_buff_title",
-										desc_id = "wolfhud_hudlist_unseen_strike_buff_desc",
-										value = {"HUDList", "BUFF_LIST", "GHOST_BUFFS", "unseen_strike"},
-										visible_reqs = {},
-										enabled_reqs = {
-											{ setting = { "HUDList", "ENABLED" }, invert = false },
-											{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
-										},
-									},
+									--{
+									--	type = "toggle",
+									--	name_id = "wolfhud_hudlist_unseen_strike_buff_title",
+									--	desc_id = "wolfhud_hudlist_unseen_strike_buff_desc",
+									--	value = {"HUDList", "BUFF_LIST", "GHOST_BUFFS", "unseen_strike"},
+									--	visible_reqs = {},
+									--	enabled_reqs = {
+									--		{ setting = { "HUDList", "ENABLED" }, invert = false },
+									--		{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
+									--	},
+									--},
 								},
 							},
 							{

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -2745,17 +2745,17 @@ if VHUDPlus then
 											{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
 										},
 									},
-									{
-										type = "toggle",
-										name_id = "wolfhud_hudlist_ammo_efficiency_buff_title",
-										desc_id = "wolfhud_hudlist_ammo_efficiency_buff_desc",
-										value = {"HUDList", "BUFF_LIST", "MASTERMIND_BUFFS", "ammo_efficiency"},
-										visible_reqs = {},
-										enabled_reqs = {
-											{ setting = { "HUDList", "ENABLED" }, invert = false },
-											{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
-										},
-									},
+									--{
+									--	type = "toggle",
+									--	name_id = "wolfhud_hudlist_ammo_efficiency_buff_title",
+									--	desc_id = "wolfhud_hudlist_ammo_efficiency_buff_desc",
+									--	value = {"HUDList", "BUFF_LIST", "MASTERMIND_BUFFS", "ammo_efficiency"},
+									--	visible_reqs = {},
+									--	enabled_reqs = {
+									--		{ setting = { "HUDList", "ENABLED" }, invert = false },
+									--		{ setting = {"HUDList", "BUFF_LIST", "show_buffs"}, invert = false },
+									--	},
+									--},
 									{
 										type = "toggle",
 										name_id = "wolfhud_hudlist_combat_medic_buff_title",

--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -5003,7 +5003,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 			class = "TimedBuffItem",
 			priority = 4,
 			color = HUDList.BuffItemBase.ICON_COLOR.STANDARD,
-			ignore = not VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "MASTERMIND_BUFFS", "ammo_efficiency"}, true)
+			ignore = true,
 		},
 		armor_break_invulnerable = {
 			perks = {6, 1},
@@ -5320,7 +5320,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 			class = "TimedBuffItem",
 			priority = 4,
 			color = HUDList.BuffItemBase.ICON_COLOR.STANDARD,
-			ignore = not VHUDPlus:getSetting({"HUDList", "BUFF_LIST", "GHOST_BUFFS", "unseen_strike"}, true),
+			ignore = true,
 		},
 		up_you_go = {
 			skills_new = tweak_data.skilltree.skills.up_you_go.icon_xy,


### PR DESCRIPTION
Some buffs doesn't seem to work, ammo efficiency isn't being displayed at all and unseen strike is being pretty wonky in displaying cooldowns and buffs 