### PR TITLE
No buff list change while in game

### DIFF
--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -1177,7 +1177,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 	function HUDListManager:_set_buff_list_height_offset()
 		local list = self:list("buff_list")
 		if list then
-			list:move(list:panel():x(), HUDListManager.ListOptions.buff_list_height_offset or 90, false)
+		--	list:move(list:panel():x(), HUDListManager.ListOptions.buff_list_height_offset or 90, false)
 		end
 	end
 


### PR DESCRIPTION
This is just a quickfix and prevents the buff list height from changing position until the game has been restarted. 

Since you can't know where the bufflist will be placed while in game with the current setting there is no point to have it moved into a position it wont be in after restart