### PR TITLE
Old hostage box option

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -404,6 +404,7 @@ if not _G.VHUDPlus then
 				},
 				BUFF_LIST = {
 					show_buffs 								= true,     --Active effects (buffs/debuffs). Also see HUDList.BuffItemBase.IGNORED_BUFFS table to ignore specific buffs that you don't want listed, or enable some of those not shown by default
+				ORIGNIAL_HOSTAGE_BOX                    = false,					
 					damage_increase							= true,
 					damage_reduction						= true,
 					melee_damage_increase					= true,

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1920,6 +1920,16 @@ if VHUDPlus then
 						visible_reqs = {}, enabled_reqs = {},
 					},
 					{
+						type = "toggle",
+						name_id = "wolfhud_original_hostage_box_title",
+						desc_id = "wolfhud_original_hostage_box_desc",
+						value = {"HUDList", "ORIGNIAL_HOSTAGE_BOX"},
+						visible_reqs = {}, 
+						enabled_reqs = {
+						    { setting = { "HUDList", "ENABLED" }, invert = false },
+						},						
+					},
+					{
 						type ="divider",
 						size = 16,
 					},

--- a/loc/chinese.json
+++ b/loc/chinese.json
@@ -1140,5 +1140,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/english.json
+++ b/loc/english.json
@@ -1142,5 +1142,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/french.json
+++ b/loc/french.json
@@ -1138,5 +1138,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/german.json
+++ b/loc/german.json
@@ -1149,5 +1149,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/korean.json
+++ b/loc/korean.json
@@ -1142,5 +1142,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/portuguese.json
+++ b/loc/portuguese.json
@@ -1145,5 +1145,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/russian.json
+++ b/loc/russian.json
@@ -1142,5 +1142,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."	
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/loc/spanish.json
+++ b/loc/spanish.json
@@ -1142,5 +1142,7 @@
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health" : "Show enemy health x10",
 	"wolfhud_enemyhealthbar_show_multiplied_enemy_health_desc" : "Shows the enemy health x10. This makes the health values consistent with weapon damage stats.",
 	"wolfhud_dmg_popup_body_glow_color_title" : "Bodyshot Glow Popup Color",
-	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color."
+	"wolfhud_dmg_popup_body_glow_color_desc" : "Configure the bodyshot glow color.",
+	"wolfhud_original_hostage_box_title" : "Show Original Hostage Box",
+	"wolfhud_original_hostage_box_desc" : "Shows the original hostage box on the hud."
 }

--- a/lua/Scripts.lua
+++ b/lua/Scripts.lua
@@ -495,7 +495,7 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudassaultcorner" then
 	function HUDAssaultCorner:init(...)
 		HUDAssaultCorner_init(self, ...)
 		local hostages_panel = self._hud_panel:child("hostages_panel")
-		if alive(hostages_panel) and VHUDPlus:getSetting({"HUDList", "ENABLED"}, true) then
+		if alive(hostages_panel) and not VHUDPlus:getSetting({"HUDList", "ORIGNIAL_HOSTAGE_BOX"}, false) then
 			hostages_panel:set_alpha(0)
 		end
 	end

--- a/lua/Scripts.lua
+++ b/lua/Scripts.lua
@@ -495,7 +495,7 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudassaultcorner" then
 	function HUDAssaultCorner:init(...)
 		HUDAssaultCorner_init(self, ...)
 		local hostages_panel = self._hud_panel:child("hostages_panel")
-		if alive(hostages_panel) and not VHUDPlus:getSetting({"HUDList", "ORIGNIAL_HOSTAGE_BOX"}, false) then
+		if alive(hostages_panel) and VHUDPlus:getSetting({"HUDList", "ENABLED"}, true) and not VHUDPlus:getSetting({"HUDList", "ORIGNIAL_HOSTAGE_BOX"}, false) then
 			hostages_panel:set_alpha(0)
 		end
 	end


### PR DESCRIPTION
This adds an additional option into hudlist which will be disabled by default. It will let you use the vanilla hostage box at the same time as you use the hudlist.

Good for some that might not like the info boxes hudlist brings and just want the info provided on the left side such as timers or the buffs.