### PR TITLE
New underdog glow

### DIFF
--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -511,8 +511,8 @@ elseif RequiredScript == "lib/managers/hud/hudteammate" then
 		local underdog_glow = radial_health_panel:bitmap({
 			valign 			= "center",
 			halign 			= "center",
-			w 				= 64,
-			h 				= 64,
+			w 				= 70,
+			h 				= 70,
 			--w 				= 50,
 			--h 				= 50,				
 			name 			= "underdog_glow",

--- a/lua/VanillaHUD.lua
+++ b/lua/VanillaHUD.lua
@@ -511,17 +511,20 @@ elseif RequiredScript == "lib/managers/hud/hudteammate" then
 		local underdog_glow = radial_health_panel:bitmap({
 			valign 			= "center",
 			halign 			= "center",
-			w 				= 50,
-			h 				= 50,
+			w 				= 64,
+			h 				= 64,
+			--w 				= 50,
+			--h 				= 50,				
 			name 			= "underdog_glow",
 			visible 		= false,
-			texture 		= "guis/textures/pd2/crimenet_marker_glow",
-			texture_rect 	= {
-								0,
-								0,
-								64,
-								64
-							},
+			texture 		= "guis/textures/pd2/hot_cold_glow",
+			--texture 		= "guis/textures/pd2/crimenet_marker_glow",
+			--texture_rect 	= {
+			--					0,
+			--					0,
+			--					64,
+			--					64
+			--				},				
 			color 			= Color.yellow,
 			layer 			= 2,
 			blend_mode 		= "add"


### PR DESCRIPTION
Changes the glow texture to one without a square around it, saved the old setup as commented in case it has to be reverted for some reason.