### PR TITLE
Possible tab stats fix

### DIFF
--- a/lua/HUDChat.lua
+++ b/lua/HUDChat.lua
@@ -30,7 +30,7 @@ if RequiredScript == "lib/managers/hud/hudchat" then
 
 	function HUDChat:init(ws, hud)
 		local fullscreen = managers.hud:script(PlayerBase.PLAYER_INFO_HUD_FULLSCREEN_PD2)
-
+		self._hud_panel = fullscreen.panel
 		self._x_offset = (fullscreen.panel:w() - hud.panel:w()) / 2
 		self._y_offset = (fullscreen.panel:h() - hud.panel:h()) / 2
 		self._esc_callback = callback(self, self, "esc_key_callback")

--- a/lua/TabStats.lua
+++ b/lua/TabStats.lua
@@ -57,6 +57,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/newhudstatsscreen" then
 			local row_w = self._left:w() - placer:current_left() * 2
 			local y = 0
 
+		    --[[		
 			for i, data in pairs(managers.objectives:get_active_objectives()) do
 				placer:add_bottom(self._left:fine_text({
 					word_wrap = true,
@@ -79,6 +80,7 @@ if string.lower(RequiredScript) == "lib/managers/hud/newhudstatsscreen" then
 				}), 0)
 				y = math.max(y, item:bottom())
 			end
+			]]		
 
 			local placer = UiPlacer:new(0, 0)
 			local ext_inv_panel = ExtendedPanel:new(self._left, {


### PR DESCRIPTION
By commenting the objective title and description the challenges will now fit.

I personally think having the objective which already is shown on the hud in the tab screen redundant.

Changing fonts worked but because the side job placement would depend on the length of the objective description it would require a lot of tweaks and even then there would be some overlapping at times.


When  taking out the objective info the side jobs fits perfectly into the screen.
![20200517170702_1](https://user-images.githubusercontent.com/30779314/82152672-35cc7f00-9863-11ea-8928-6e4442820ecb.jpg)
 