### PR TITLE
no red lasers

### DIFF
--- a/lua/NetworkHandler.lua
+++ b/lua/NetworkHandler.lua
@@ -11,6 +11,22 @@ function UnitNetworkHandler:sync_contour_state(unit, u_id, type, state, multipli
 	end
 end
 
+function UnitNetworkHandler:set_weapon_gadget_color(unit, red, green, blue, sender)
+	if not self._verify_character_and_sender(unit, sender) then
+		return
+	end
+
+	if red and green and blue then 
+		local threshold = 0.66
+		if red * threshold > green + blue then
+			red = 1
+			green = 51
+			blue = 1
+		end
+	end
+	unit:inventory():sync_weapon_gadget_color(Color(red / 255, green / 255, blue / 255))
+end
+
 --[[
 do return end	-- Disabled cause: WiP
 VHUDPlus.Sync = VHUDPlus.Sync or {}


### PR DESCRIPTION
Just an idea to sneak in no red lasers by [Offyerrocker](https://modworkshop.net/mod/21990)

I find it to be a pretty great QoL script and it would be nice to get rid of the red lasers without having to overwrite the team lasers all together