### PR TITLE
fix profile preview stretching over too many profiles

### DIFF
--- a/ProfileMenu.lua
+++ b/ProfileMenu.lua
@@ -127,7 +127,8 @@ elseif RequiredScript == "lib/managers/menu/renderers/menunodeskillswitchgui" th
 
 		if alive(self.item_panel) and LoadoutPanel then
 			local offset_h = managers.menu:is_pc_controller() and 25 or 0
-			self.profile_preview = LoadoutPanel:new(self.item_panel:parent(), self, 0, self.PROFILE_PREVIEW_W, math.floor(self.item_panel:h()) - offset_h, {
+			local height = math.min(math.floor(self.item_panel:h()), ws_panel:height())
+			self.profile_preview = LoadoutPanel:new(self.item_panel:parent(), self, 0, self.PROFILE_PREVIEW_W, height - offset_h, {
 				component_layout = {
 					{ "skills" },
 					{ "perk" },
@@ -142,6 +143,7 @@ elseif RequiredScript == "lib/managers/menu/renderers/menunodeskillswitchgui" th
 			})
 			local outfit = managers.multi_profile:get_profile_outfit(managers.multi_profile:current_profile_id())
 			self.profile_preview:set_outfit(outfit)
+			self.profile_preview:set_top(0)
 		end
 	end
 


### PR DESCRIPTION
if you're using mods that add extra profiles, the loadout panel will stretch too much to the point where you're unable to see it.
this fixes it, by using the parent's height (the actual window of the profile selector) instead.