### PR TITLE
vanillahud.lua: refactor custody scaling

### DIFF
--- a/devlua/VanillaHUD.lua
+++ b/devlua/VanillaHUD.lua
@@ -1026,64 +1026,37 @@ if VHUDPlus:getSetting({"CustomHUD", "HUDTYPE"}, 2) == 2 then
 		local set_negotiating_visible_orig  = HUDPlayerCustody.set_negotiating_visible
 		local set_can_be_trade_visible_orig = HUDPlayerCustody.set_can_be_trade_visible
 
-		function HUDPlayerCustody:set_negotiating_visible(...)
-		set_negotiating_visible_orig(self, ...)
-			local trade_text = self._hud.trade_text2
+		local vhudplus_getCustodyOffset = function()
+			local scale = VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1)
+			--[[ Old values:
+			Scale, offset
+			0.55, 720
+			... in steps of 0.05
+			1.00, 145
+			else  80
 
-			if VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.55 then
-				offset = 720
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.60 then
-				offset = 660
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.65 then
-				offset = 595
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.70 then
-				offset = 530
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.75 then
-				offset = 465
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.80 then
-				offset = 400
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.85 then
-				offset = 335
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.90 then
-				offset = 275
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
-				offset = 210
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
-				offset = 145
-			else
-				offset = 80 
-			end
+			linear regression: f(x) = -64.15*x + 786
+			Note: was this ever tested for non-1080p resolutions?
+			This probably must be some ratio of screen height rather than hardcoded pixel position
+			]]
+			local offset = math.floor(-64.15 * scale + 786)
+			return math.clamp(offset, 720, 80)
+		end
+
+		function HUDPlayerCustody:set_negotiating_visible(...)
+			set_negotiating_visible_orig(self, ...)
+
+			local trade_text = self._hud.trade_text2
+			local offset = vhudplus_getCustodyOffset()
 
 			trade_text:set_right(self._hud.trade_text2:w() + offset )
 		end
 
 		function HUDPlayerCustody:set_can_be_trade_visible(...)
-		set_can_be_trade_visible_orig(self, ...)
+			set_can_be_trade_visible_orig(self, ...)
+
 			local trade_text = self._hud.trade_text1
-			
-			if VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.55 then
-				offset = 720
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.60 then
-				offset = 660
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.65 then
-				offset = 595
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.70 then
-				offset = 530
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.75 then
-				offset = 465
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.80 then
-				offset = 400
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.85 then
-				offset = 335
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.90 then
-				offset = 275
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 0.95 then
-				offset = 210
-			elseif VHUDPlus:getSetting({"CustomHUD", "HUD_SCALE"}, 1) < 1 then
-				offset = 145
-			else
-				offset = 80 
-			end
+			local offset = vhudplus_getCustodyOffset()
 			
 			trade_text:set_right(self._hud.trade_text1:w() + offset )
 		end


### PR DESCRIPTION
CSV:

```
HUD Scale	Offset
0.55	720
0.6	660
0.65	595
0.7	530
0.75	465
0.8	400
0.85	332
0.90	275
0.95	210
1.00	145
1.05	80
```

![graph](https://github.com/steam-test1/VPlusHUD/assets/129969897/f91f5303-7516-40c0-a97d-3f8394fcf377)

> Note: was this ever tested for non-1080p resolutions?
This probably must be some ratio of screen height rather than hardcoded pixel position

Change not tested, I suppose proper testing is to verify all that works as expected for tiny & big resolutions with min/max scaling. Feel free to postpone until I got time test

---

**Edit:** There exists `managers.gui_data:safe_to_full_16_9`